### PR TITLE
fix(ci): pin prepare-pypi-distribution workflow to working commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
 
                      echo "✓ Version check passed: pyproject.toml has correct version $ACTUAL_VERSION"
             - name: Prepare distribution
-              uses: apify/workflows/prepare-pypi-distribution@main
+              uses: apify/workflows/prepare-pypi-distribution@e9d8b247c5be28889b1f6df1e23a991c3d0f6305
               with:
                 ref: ${{ needs.update_version.outputs.version_commitish }}
                 package_name: mcp-client-capabilities


### PR DESCRIPTION
## Summary
- Pins `apify/workflows/prepare-pypi-distribution` to commit `e9d8b247c5be28889b1f6df1e23a991c3d0f6305` instead of `@main`
- Fixes CI failure caused by broken changes in the upstream shared workflow

## Root Cause
The latest version of `prepare-pypi-distribution@main` is missing the `poethepoet` dependency, causing the `poe install-dev` command to fail with:
```
error: Failed to spawn: `poe`
  Caused by: No such file or directory (os error 2)
```

## Fix
Pin to the last known working commit until the upstream workflow is fixed.